### PR TITLE
Fix Drupal coding standards in Drush aliases template

### DIFF
--- a/Resources/templates/aliases.php.twig
+++ b/Resources/templates/aliases.php.twig
@@ -1,11 +1,9 @@
 <?php
 
-{% for alias in aliases|slice(0,1) %}
 /**
  * @file
- * Drush site-alias configuration for {{ aliases["ac-site"] }}.
+ * Drush site-alias configuration.
  */
-{% endfor %}
 
 if (!isset($drush_major_version)) {
   $drush_version_components = explode('.', DRUSH_VERSION);

--- a/Resources/templates/aliases.php.twig
+++ b/Resources/templates/aliases.php.twig
@@ -1,5 +1,12 @@
 <?php
 
+{% for alias in aliases|slice(0,1) %}
+/**
+ * @file
+ * Drush site-alias configuration for {{ aliases["ac-site"] }}.
+ */
+{% endfor %}
+
 if (!isset($drush_major_version)) {
   $drush_version_components = explode('.', DRUSH_VERSION);
   $drush_major_version = $drush_version_components[0];
@@ -7,7 +14,7 @@ if (!isset($drush_major_version)) {
 
 {% for alias in aliases %}
 {% if alias["parent"] %}
-// Site {{alias["site"]}}, environment {{alias["env"]}}, domain {{alias["uri"]}}
+// Site {{alias["site"]}}, environment {{alias["env"]}}, domain {{alias["uri"]}}.
 $aliases['{{alias["site"]}}'] = array(
   'parent' => '{{alias["parent"]}}',
   'uri' => '{{alias["uri"]}}',
@@ -21,7 +28,7 @@ $aliases['{{alias["env"]}}'] = array(
   ),
 );
 {% else %}
-// Site {{alias["ac-site"]}}, environment {{alias["env-name"]}}
+// Site {{alias["ac-site"]}}, environment {{alias["env-name"]}}.
 $aliases['{{alias["ac-env"]}}'] = array(
   'root' => '{{alias["root"]}}',
   'ac-site' => '{{alias["ac-site"]}}',
@@ -32,7 +39,7 @@ $aliases['{{alias["ac-env"]}}'] = array(
   'remote-user' => '{{alias["remote-user"]}}',
   'path-aliases' => array(
     '%drush-script' => 'drush' . $drush_major_version,
-  )
+  ),
 );
 $aliases['{{alias["ac-env"]}}.livedev'] = array(
   'parent' => '@{{alias["ac-site"]}}.{{alias["ac-env"]}}',


### PR DESCRIPTION
## Proposed Changes

- Add missing file doc comment
- Add full-stops to end of inline comments
- Add comma following last multiline array items

## Related Issues

- #37 