### PR TITLE
Fix deprecated Drush aliases 'parent' key

### DIFF
--- a/Resources/templates/aliases.php.twig
+++ b/Resources/templates/aliases.php.twig
@@ -35,8 +35,7 @@ $aliases['{{alias["ac-env"]}}'] = array(
   )
 );
 $aliases['{{alias["ac-env"]}}.livedev'] = array(
-  'parent' => '@{{alias["ac-site"]}}.{{alias["ac-env"]}}',
   'root' => '/mnt/gfs/{{alias["ac-site"]}}.{{alias["ac-env"]}}/livedev/docroot',
-);
+) + $aliases['{{alias["ac-env"]}}'];
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Proposed Changes

The Drush site-alias key 'parent' has been deprecated. The proper way to duplicate an alias from a parent is with a PHP array union. 

See Drush project `example.aliases.drushrc.php` for details:

- [Drush site alias 'parent'](https://github.com/drush-ops/drush/blob/master/examples/example.aliases.drushrc.php#L213)

- [Drush example Altering aliases](https://github.com/drush-ops/drush/blob/master/examples/example.aliases.drushrc.php#L275-L290)

## Related Issues

- #40 raised new issue for deprecated key
- #37 originally discussed relating to coding standards for aliases