### PR TITLE
Reduce version variables in Drush aliases global scope

### DIFF
--- a/Resources/templates/aliases.php.twig
+++ b/Resources/templates/aliases.php.twig
@@ -1,8 +1,7 @@
 <?php
 
 if (!isset($drush_major_version)) {
-  $drush_version_components = explode('.', DRUSH_VERSION);
-  $drush_major_version = $drush_version_components[0];
+  list($drush_major_version) = explode('.', DRUSH_VERSION);
 }
 
 {% for alias in aliases %}


### PR DESCRIPTION
## Proposed Changes

Get the Drush major version without leaving behind unused Global scope variables.

Any variables set in the Drush aliases file will be left over in the Global scope. Keeping the Global scope clean and reducing the Global scope variables defined is a best practice we should follow.

## Related Issues

- #37 originally discussed relating to coding standards for aliases